### PR TITLE
Ability to give a filename as first argument to haste client

### DIFF
--- a/lib/haste.rb
+++ b/lib/haste.rb
@@ -12,8 +12,20 @@ module Haste
 
     # Pull all of the data from STDIN
     def initialize
-      @input = STDIN.readlines.join
-      @input.strip!
+      if STDIN.tty?
+        if ARGV.empty?
+          puts "No input file given"
+          exit
+        end
+        
+        file = ARGV[0]
+        abort "#{file} doesn't exist" unless File.exists?(file)
+        
+        @input = open(file).read.strip
+      else
+        @input = STDIN.readlines.join
+        @input.strip!
+      end
     end
 
     # Upload the and output the URL we get back


### PR DESCRIPTION
This patch makes it possible to either pipe data into the haste client,
or just give a filename as first argument.

Signed-off-by: Peter Haza
