### PR TITLE
`HASTE_SERVER` variable should be `dup`ed

### DIFF
--- a/lib/haste.rb
+++ b/lib/haste.rb
@@ -33,7 +33,7 @@ module Haste
       else
         abort "failure uploading: #{response.code}"
       end
-    rescue RuntimeError, JSON::ParserError => e
+    rescue JSON::ParserError => e
       abort "failure uploading: #{response.code}"
     rescue Errno::ECONNREFUSED => e
       abort "failure connecting: #{e.message}"
@@ -43,7 +43,7 @@ module Haste
 
     def server
       return @server if @server
-      @server = ENV['HASTE_SERVER'] || Haste::DEFAULT_URL
+      @server = ENV['HASTE_SERVER'].dup() || Haste::DEFAULT_URL
       @server.chop! if server.end_with?('/')
       @server
     end


### PR DESCRIPTION
This is my first toe-dipping into Ruby. Not 100% if is the right way to fix. 

Here is the traceback I was getting.

```
jokull.air~/Code/haste-server: heroku logs | hastebin 
/Users/jokull/Code/haste-client/lib/haste.rb:47:in `chop!': can't modify frozen String (RuntimeError)
    from /Users/jokull/Code/haste-client/lib/haste.rb:47:in `server'
    from /Users/jokull/Code/haste-client/lib/haste.rb:26:in `start'
    from /Users/jokull/Code/haste-client/bin/haste:8:in `<main>'
```
