### PR TITLE
Initializing "file" local var so as to avoid explosions

### DIFF
--- a/lib/haste.rb
+++ b/lib/haste.rb
@@ -11,6 +11,7 @@ module Haste
     # Pull all of the data from STDIN
     def initialize
       if STDIN.tty?
+        file = nil
         abort 'No input file given' unless ARGV.length == 1
         abort "#{file}: No such path" unless File.exists?(file = ARGV[0])
         @input = open(file).read


### PR DESCRIPTION
that are probably confusing and scary for folks unfamiliar with Ruby
backtraces.

Steps to reproduce:

``` bash
# in the haste-client working copy
ruby -I.:./lib bin/haste foo
/Users/d.buch/workspace/haste-client/lib/haste.rb:15:in `initialize': undefined local variable or method `file' for #<Haste::CLI:0x007ff25b96eab0> (NameError)
        from bin/haste:7:in `new'
        from bin/haste:7:in `<main>'
```
