### PR TITLE
Make HTTPS support to actually work (require 'net/https')

### DIFF
--- a/lib/haste.rb
+++ b/lib/haste.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'net/http'
+require 'net/https'
 require 'uri'
 
 module Haste


### PR DESCRIPTION
... by adding `require 'net/https'` at the beginning of haste.rb
