### PR TITLE
Do not trim leading whitespace

### DIFF
--- a/lib/haste.rb
+++ b/lib/haste.rb
@@ -20,7 +20,7 @@ module Haste
         @input = STDIN.readlines.join
       end
       # clean up
-      @input.strip!
+      @input.rstrip!
     end
 
     # Upload the and output the URL we get back


### PR DESCRIPTION
For pastes of code snippets, removing leading whitespace usually
results in mis-aligned code.
